### PR TITLE
Update GitHub actions to avoid use of Node 12

### DIFF
--- a/.github/workflows/build-and-publish-to-github-pages.yaml
+++ b/.github/workflows/build-and-publish-to-github-pages.yaml
@@ -26,9 +26,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Run Antora
-        uses: kameshsampath/antora-site-action@v0.2.4
+        uses: kameshsampath/antora-site-action@v0.3.0
         with:
           antora_playbook: antora-playbook.yml
       - name: Publish to GitHub Pages

--- a/.github/workflows/build-and-validate-on-pr.yaml
+++ b/.github/workflows/build-and-validate-on-pr.yaml
@@ -27,7 +27,7 @@ jobs:
     container: "quay.io/eclipse/che-docs:latest"
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           fetch-depth: 0 # Necessary for git diff in vale step
 
@@ -36,7 +36,7 @@ jobs:
         run: CI=true antora generate antora-playbook-for-development.yml --stacktrace 2>&1 | (tee | grep  WARNING && exit 42 || exit 0)
 
       - name: Upload artifact doc-content
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: doc-content
           path: build/site
@@ -47,19 +47,19 @@ jobs:
           echo "${{ github.event.pull_request.head.sha }}" > PR_SHA
 
       - name: Upload artifact pull-request-number for publish-netlify
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: pull-request-number
           path: PR_NUMBER
 
       - name: Upload artifact pull-request-sha for publish-netlify
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: pull-request-sha
           path: PR_SHA
 
       - name: Cache htmltest status code of checked external URLs # See: https://docs.github.com/en/actions/guides/caching-dependencies-to-speed-up-workflows
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         env:
           cache-name: cache-htmltest
         with:

--- a/.github/workflows/build-and-validate-on-push.yaml
+++ b/.github/workflows/build-and-validate-on-push.yaml
@@ -27,7 +27,7 @@ jobs:
     container: "quay.io/eclipse/che-docs:latest"
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           fetch-depth: 0
 
@@ -36,13 +36,13 @@ jobs:
         run: CI=true antora generate antora-playbook-for-development.yml --stacktrace
 
       - name: Upload artifact
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: doc-content
           path: build/site
 
       - name: Cache htmltest status code of checked external URLs # See: https://docs.github.com/en/actions/guides/caching-dependencies-to-speed-up-workflows
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         env:
           cache-name: cache-htmltest
         with:

--- a/.github/workflows/publish-netlify.yml
+++ b/.github/workflows/publish-netlify.yml
@@ -73,7 +73,7 @@ jobs:
           NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}
 
       - name: Comment the pull-request
-        uses: actions/github-script@v3.0.0
+        uses: actions/github-script@v6
         with:
           script: |
             const { repo: { owner, repo } } = context;


### PR DESCRIPTION
Update GitHub actions to avoid use of Node 12, which is deprecated.

This PR does not fix warnings around usage of `set-output`, as these are coming from `netlify/actions/cli`, which has not updated in a year.